### PR TITLE
Prevent missing attributes to raise an error in activerecord

### DIFF
--- a/lib/jsonb_accessor/macro.rb
+++ b/lib/jsonb_accessor/macro.rb
@@ -44,7 +44,7 @@ module JsonbAccessor
           jsonb_values = public_send(jsonb_attribute) || {}
           jsonb_values.each do |store_key, value|
             name = names_and_store_keys.key(store_key)
-            write_attribute(name, value)
+            write_attribute(name, value) if name
           end
           clear_changes_information if persisted?
         end


### PR DESCRIPTION
If an extra attribute is in the jsonb and not in model declaration, it was raising an error